### PR TITLE
FIX: Overlapped excerpt on pinned topics

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -4,6 +4,10 @@
   display: none;
 }
 
+.voting-category .topic-list .pinned .topic-excerpt {
+  margin-left: 65px;
+}
+
 .voting-category.list-container {
   
   @if $use_compact_width == "true" {


### PR DESCRIPTION
Reported by a customer -- this should fix where the voting buttons overlapped with the excerpt on a pinned topic in a voting category.